### PR TITLE
Add NodePath

### DIFF
--- a/include/gobot/core/marcos.hpp
+++ b/include/gobot/core/marcos.hpp
@@ -64,15 +64,6 @@
 #endif
 
 
-#if defined(__GNUC__)
-#define likely(x) __builtin_expect(!!(x), 1)
-#define unlikely(x) __builtin_expect(!!(x), 0)
-#else
-#define likely(x) x
-#define unlikely(x) x
-#endif
-
-
 namespace rttr::detail
 {
 template<typename Ctor_Type, typename Policy, typename Accessor, typename Arg_Indexer>

--- a/include/gobot/core/marcos.hpp
+++ b/include/gobot/core/marcos.hpp
@@ -64,6 +64,14 @@
 #endif
 
 
+#if defined(__GNUC__)
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#else
+#define likely(x) x
+#define unlikely(x) x
+#endif
+
 
 namespace rttr::detail
 {

--- a/include/gobot/core/marcos.hpp
+++ b/include/gobot/core/marcos.hpp
@@ -54,6 +54,8 @@
 
 #define GOB_UNUSED(x) (void)x;
 
+#define GOB_STRINGIFY(x) #x
+
 
 #ifdef _MSC_VER
 #define GENERATE_TRAP() __debugbreak()

--- a/include/gobot/core/types.hpp
+++ b/include/gobot/core/types.hpp
@@ -19,6 +19,7 @@ using Type = rttr::type;
 using VarintListView = rttr::variant_sequential_view;
 using VarintMapView  = rttr::variant_associative_view;
 using Instance = rttr::instance;
+using Property = rttr::property;
 using Method = rttr::method;
 using Argument = rttr::argument;
 using Enumeration = rttr::enumeration;

--- a/include/gobot/error_marcos.hpp
+++ b/include/gobot/error_marcos.hpp
@@ -1,0 +1,34 @@
+/* The gobot is a robot simulation platform. 
+ * Copyright(c) 2021-2023, RobSimulatorGroup, Qiqi Wu<1258552199@qq.com>.
+ * Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+ * This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License.
+ * This file is created by Qiqi Wu, 23-1-14
+*/
+
+#pragma once
+
+#include "gobot/log.hpp"
+#include "gobot/core/marcos.hpp"
+
+#define ERR_FAIL_COND(cond)                                                                    \
+	if (cond) [[unlikely]] {                                                                   \
+        LOG_ERROR("Failed condition {}.", GOB_STRINGIFY(cond));                                \
+		return;                                                                                \
+	} else                                                                                     \
+		((void)0)
+
+
+#define ERR_FAIL_COND_V(cond, ret)                                                              \
+	if (cond) [[unlikely]] {                                                                    \
+        LOG_ERROR("Failed condition {}. Return: {}", GOB_STRINGIFY(cond), GOB_STRINGIFY(ret));  \
+		return ret;                                                                             \
+	} else                                                                                      \
+		((void)0)
+
+
+#define ERR_FAIL_COND_MSG(cond, msg)                                                            \
+	if (cond) [[unlikely]] {                                                                    \
+        LOG_ERROR("Failed condition {}. {}", GOB_STRINGIFY(cond), GOB_STRINGIFY(msg));          \
+		return;                                                                                 \
+	} else                                                                                      \
+		((void)0)

--- a/include/gobot/error_marcos.hpp
+++ b/include/gobot/error_marcos.hpp
@@ -32,3 +32,30 @@
 		return;                                                                                 \
 	} else                                                                                      \
 		((void)0)
+
+
+/**
+ * Try using `ERR_FAIL_INDEX_V_MSG`.
+ * Only use this macro if there is no sensible error message.
+ *
+ * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
+ * If not, the current function returns `m_retval`.
+ */
+#define ERR_FAIL_INDEX_MSG(index, size, msg)                                                    \
+    if (unlikely((index) < 0 || (index) >= (size))) {                                           \
+        LOG_ERROR("Invalid index {} out of {}. {}", index, size, GOB_STRINGIFY(msg));           \
+        return;                                                                                 \
+    } else                                                                                      \
+        ((void)0)
+
+
+/**
+ * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
+ * If not, prints `m_msg` and the current function returns `m_retval`.
+ */
+#define ERR_FAIL_INDEX_V(index, size, ret)                                                      \
+    if (unlikely((index) < 0 || (index) >= (size))) {                                           \
+        LOG_ERROR("Invalid index {} out of {}, return {}.", idx, size, GOB_STRINGIFY(ret));     \
+        return ret;                                                                             \
+    } else                                                                                      \
+        ((void)0)

--- a/include/gobot/error_marcos.hpp
+++ b/include/gobot/error_marcos.hpp
@@ -42,7 +42,7 @@
  * If not, the current function returns `m_retval`.
  */
 #define ERR_FAIL_INDEX_MSG(index, size, msg)                                                    \
-    if (unlikely((index) < 0 || (index) >= (size))) {                                           \
+    if ((index) < 0 || (index) >= (size)) [[unlikely]] {                                        \
         LOG_ERROR("Invalid index {} out of {}. {}", index, size, GOB_STRINGIFY(msg));           \
         return;                                                                                 \
     } else                                                                                      \
@@ -54,7 +54,7 @@
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
 #define ERR_FAIL_INDEX_V(index, size, ret)                                                      \
-    if (unlikely((index) < 0 || (index) >= (size))) {                                           \
+    if ((index) < 0 || (index) >= (size)) [[unlikely]] {                                        \
         LOG_ERROR("Invalid index {} out of {}, return {}.", idx, size, GOB_STRINGIFY(ret));     \
         return ret;                                                                             \
     } else                                                                                      \

--- a/include/gobot/log.hpp
+++ b/include/gobot/log.hpp
@@ -88,3 +88,6 @@ struct fmt::formatter<gobot::String> : fmt::formatter<std::string>
 #define LOG_WARN(...)  gobot::Logger::getInstance().getLogger()->warn("[" __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) "] " __VA_ARGS__)
 #define LOG_ERROR(...) gobot::Logger::getInstance().getLogger()->error("[" __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) "] " __VA_ARGS__)
 #define LOG_FATAL(...) gobot::Logger::getInstance().getLogger()->critical("[" __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) "] " __VA_ARGS__)
+
+#define LOG_OFF gobot::Logger::getInstance().getLogger()->set_level(spdlog::level::off)
+#define LOG_ON gobot::Logger::getInstance().getLogger()->set_level(spdlog::level::trace)

--- a/include/gobot/log.hpp
+++ b/include/gobot/log.hpp
@@ -19,6 +19,7 @@
 #include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/rotating_file_sink.h>
+#include "gobot/core/types.hpp"
 
 
 namespace gobot {

--- a/include/gobot/scene/node.hpp
+++ b/include/gobot/scene/node.hpp
@@ -8,19 +8,105 @@
 #pragma once
 
 #include "gobot/core/object.hpp"
+#include "gobot/error_marcos.hpp"
 
 namespace gobot {
 
+class NodePath;
+class SceneTree;
+
 class Node : public Object {
     GOBCLASS(Node, Object)
-
 public:
-
     Node();
 
-private:
-    std::vector<Node*> children_node_;
+    ~Node();
 
+    Node(const String& name);
+
+    String GetName() const;
+
+    void SetName(const String & name);
+
+    void AddChild(Node *child);
+
+    void AddSibling(Node *sibling);
+
+    void RemoveChild(Node *child);
+
+    Node* GetChild(int p_index) const;
+
+    bool HasNode(const NodePath& path) const;
+
+    // https://docs.godotengine.org/zh_CN/stable/tutorials/scripting/scene_unique_nodes.html
+    Node* GetNode(const NodePath &path) const;
+
+    Node* GetNodeOrNull(const NodePath &path) const;
+
+    Node* GetParent() const;
+
+    void PrintTree();
+
+    void PrintTreePretty();
+
+    FORCE_INLINE SceneTree* GetTree() const {
+        ERR_FAIL_COND_V(!tree_, nullptr);
+        return tree_;
+    }
+
+    FORCE_INLINE bool IsInsideTree() const { return inside_tree_; }
+
+    bool IsAncestorOf(const Node *node) const;
+
+    NodePath GetPath() const;
+
+    NodePath GetPathTo(const Node *node) const;
+
+    Node* FindCommonParentWith(const Node* node) const;
+
+protected:
+    void AddChildNoCheck(Node *child, const String& name);
+
+    void SetNameNoCheck(const String& name);
+
+    void SetOwnerNoCheck(Node *owner);
+
+    void Notification(NotificationType notification);
+
+private:
+    friend class SceneTree;
+
+    void PropagateReverseNotification(int p_notification);
+
+    void PropagateEnterTree();
+
+    void PropagateReady();
+
+    void PropagateExitTree();
+
+    void PropagateAfterExitTree();
+
+    friend class SceneTree;
+
+    void SetTree(SceneTree* tree);
+
+    Node *GetChildByName(const String& name) const;
+
+    void ValidateChildName(Node* child);
+
+    void GenerateSerialChildName(const Node* child, String&name) const;
+
+private:
+    String name_;
+    std::vector<Node*> children_node_;
+    mutable NodePath *path_cache_ = nullptr;
+
+    bool inside_tree_ = false;
+    SceneTree* tree_ = nullptr;
+
+    Node* parent_ = nullptr;
+
+    // TODO(wqq): Do we need ower?
 };
 
 }

--- a/include/gobot/scene/node.hpp
+++ b/include/gobot/scene/node.hpp
@@ -20,7 +20,7 @@ class Node : public Object {
 public:
     Node();
 
-    ~Node();
+    ~Node() = default;
 
     Node(const String& name);
 

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -8,9 +8,10 @@
 
 #pragma once
 
-#include "gobot/log.hpp"
 #include "gobot/error_marcos.hpp"
 #include "gobot/core/types.hpp"
+#include "gobot/core/marcos.hpp"
+#include "gobot/log.hpp"
 #include <vector>
 #include <QStringList>
 
@@ -51,7 +52,7 @@ public:
      *
      * @returns number of node names.
      */
-    [[nodiscard]] ulong GetNameCount() const;
+    [[nodiscard]] std::size_t GetNameCount() const;
 
     /**
      * @brief Gets the node name indicated by idx (0 to GetNameCount - 1).
@@ -68,7 +69,7 @@ public:
      *
      * @returns number of node subnames.
      */
-    [[nodiscard]] ulong GetSubNameCount() const;
+    [[nodiscard]] std::size_t GetSubNameCount() const;
 
     /**
      * @brief Gets the resource or property name indicated by idx (0 to GetSubnameCount).
@@ -143,6 +144,11 @@ public:
     [[nodiscard]] NodePath Simplified() const;
 
 private:
+    // For rttr
+    void SetStrData(const String& str);
+
+    String GeStrData();
+
     struct Data {
         std::vector<String> path = std::vector<String>();
         std::vector<String> subpath = std::vector<String>();
@@ -155,7 +161,18 @@ private:
 
     mutable Data data_;
 
-    static constexpr Qt::SplitBehaviorFlags S_FLAG_SKIP_EMPTY_PARTS = Qt::SkipEmptyParts;
+    static constexpr Qt::SplitBehaviorFlags s_split_behavior_flags = Qt::SkipEmptyParts;
+
+    GOBOT_REGISTRATION_FRIEND
 };
 
 }
+
+template<>
+struct fmt::formatter<gobot::NodePath> : fmt::formatter<std::string>
+{
+    static auto format(const gobot::NodePath& node_path, format_context &ctx) -> decltype(ctx.out())
+    {
+        return fmt::formatter<gobot::String>::format(node_path.operator gobot::String(), ctx);
+    }
+};

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "gobot/log.hpp"
 #include "gobot/core/types.hpp"
 #include <vector>
 #include <QStringList>
@@ -18,34 +19,35 @@ using StringList = QStringList;
 
 class NodePath {
 public:
-    NodePath();
-
     NodePath(const std::vector<String>& path, bool absolute);
+    NodePath(const std::vector<String>& path, const std::vector<String>& subpath, bool absolute);
+    NodePath(const NodePath& path);
+    explicit NodePath(const String& path);
+    NodePath() = default;
+    ~NodePath() = default;
 
-    NodePath(const NodePath& path) = default;
-
-    NodePath& operator=(const NodePath &path) = default;
-
-    NodePath(const String& path);
-
-    bool IsAbsolute() const;
-
+    [[nodiscard]] bool IsAbsolute() const;
+    [[nodiscard]] ulong GetNameCount() const;
+    [[nodiscard]] String GetName(int idx) const;
+    [[nodiscard]] ulong GetSubNameCount() const;
+    [[nodiscard]] String GetSubName(int idx) const;
+    [[nodiscard]] std::vector<String> GetNames() const;
+    [[nodiscard]] std::vector<String> GetSubNames() const;
     void Simplify();
-
     NodePath Simplified() const;
-
     bool IsEmpty() const;
-
     operator String() const;
 
+    NodePath& operator=(const NodePath &path) = default;
     bool operator==(const NodePath &path) const;
-
     bool operator!=(const NodePath &path) const;
 
 private:
     std::vector<String> path_;
     std::vector<String> subpath_;
-    bool absolute_;
+    bool valid_ = false;
+    bool absolute_ = false;
+
 };
 
 }

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -9,15 +9,18 @@
 
 #include "gobot/core/types.hpp"
 #include <vector>
+#include <QStringList>
 
 
 namespace gobot {
+
+using StringList = QStringList;
 
 class NodePath {
 public:
     NodePath();
 
-    NodePath(const std::vector<String> &path, bool absolute);
+    NodePath(const std::vector<String>& path, bool absolute);
 
     NodePath(const NodePath& path) = default;
 
@@ -41,6 +44,7 @@ public:
 
 private:
     std::vector<String> path_;
+    std::vector<String> subpath_;
     bool absolute_;
 };
 

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "gobot/log.hpp"
+#include "gobot/error_marcos.hpp"
 #include "gobot/core/types.hpp"
 #include <vector>
 #include <QStringList>

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -28,7 +28,6 @@ class NodePath {
  *  A NodePath is composed of a list of slash-separated node names (like a filesystem path) and
  *  an optional colon-separated list of "subnames" which can be resources or properties.
  */
-
 public:
     NodePath(const std::vector<String> &path, bool absolute);
     NodePath(const std::vector<String> &path, const std::vector<String> &subpath, bool absolute);
@@ -105,7 +104,7 @@ public:
     * @brief Gets all subnames concatenated with a colon character (:) as separator,
     *  i.e. the right side of the first colon in a node path.
     *
-    * @returns a String of resource of property path.
+    * @returns a String of resource or property path.
     */
     [[nodiscard]] String GetConcatenatedSubNames() const;
 
@@ -145,14 +144,16 @@ public:
 
 private:
     struct Data {
-        std::vector<String> path_ = std::vector<String>();
-        std::vector<String> subpath_ = std::vector<String>();
-        String concatenated_path_ = String();
-        String concatenated_subpath_ = String();
-        bool absolute_ = false;
+        std::vector<String> path = std::vector<String>();
+        std::vector<String> subpath = std::vector<String>();
+        String concatenated_path = String();
+        String concatenated_subpath = String();
+        bool absolute = false;
     };
 
     mutable Data data_;
+
+    static constexpr Qt::SplitBehaviorFlags S_FLAG_SKIP_EMPTY_PARTS = Qt::SkipEmptyParts;
 };
 
 }

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -16,13 +16,11 @@
 
 namespace gobot {
 
-using StringList = QStringList;
-
 class NodePath {
 public:
     NodePath(const std::vector<String> &path, bool absolute);
     NodePath(const std::vector<String> &path, const std::vector<String> &subpath, bool absolute);
-    NodePath(const NodePath &path);
+    NodePath(const NodePath &path) = default;
     explicit NodePath(const String &path);
     NodePath() = default;
     ~NodePath() = default;
@@ -34,7 +32,10 @@ public:
     [[nodiscard]] String GetSubName(int idx) const;
     [[nodiscard]] std::vector<String> GetNames() const;
     [[nodiscard]] std::vector<String> GetSubNames() const;
+    [[nodiscard]] String GetConcatenatedNames() const;
+    [[nodiscard]] String GetConcatenatedSubNames() const;
 
+    [[nodiscard]] NodePath GetAsPropertyPath() const;
     explicit operator String() const;
     [[nodiscard]] bool IsEmpty() const;
 
@@ -46,11 +47,15 @@ public:
     [[nodiscard]] NodePath Simplified() const;
 
 private:
-    std::vector<String> path_;
-    std::vector<String> subpath_;
-    bool valid_ = false;
-    bool absolute_ = false;
+    struct Data {
+        std::vector<String> path_ = std::vector<String>();
+        std::vector<String> subpath_ = std::vector<String>();
+        String concatenated_path_ = String();
+        String concatenated_subpath_ = String();
+        bool absolute_ = false;
+    };
 
+    mutable Data data_;
 };
 
 }

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -147,7 +147,7 @@ private:
     // For rttr
     void SetStrData(const String& str);
 
-    String GeStrData();
+    String GetStrData();
 
     struct Data {
         std::vector<String> path = std::vector<String>();

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -125,7 +125,7 @@ public:
      */
     [[nodiscard]] bool IsEmpty() const;
 
-    bool operator==(const NodePath &path) const;
+    bool operator==(const NodePath &path) const = default;
     bool operator!=(const NodePath &path) const;
     NodePath& operator=(const NodePath &path) = default;
 
@@ -149,6 +149,8 @@ private:
         String concatenated_path = String();
         String concatenated_subpath = String();
         bool absolute = false;
+
+        bool operator==(const Data &data) const = default;
     };
 
     mutable Data data_;

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -18,6 +18,17 @@
 namespace gobot {
 
 class NodePath {
+/**
+ * @brief pre-parsed scene tree path.
+ *  A pre-parsed relative or absolute path in a scene tree, for use with Node.get_node and similar functions.
+ *  It can reference a node, a resource within a node, or a property of a node or resource.
+ *  For example, "Path2D/PathFollow2D/Sprite2D:texture:size" would refer to the size property of the texture resource
+ *  on the node named "Sprite2D" which is a child of the other named nodes in the path.
+ *
+ *  A NodePath is composed of a list of slash-separated node names (like a filesystem path) and
+ *  an optional colon-separated list of "subnames" which can be resources or properties.
+ */
+
 public:
     NodePath(const std::vector<String> &path, bool absolute);
     NodePath(const std::vector<String> &path, const std::vector<String> &subpath, bool absolute);
@@ -26,25 +37,110 @@ public:
     NodePath() = default;
     ~NodePath() = default;
 
+    /**
+     * @brief Absolute node paths can be used to access the root node ("/root") or autoloads
+     *  (e.g. "/global" if a "global" autoload was registered).
+     *
+     * @returns true if the node path is absolute (as opposed to relative), which means that it starts with a
+     *  slash character (/).
+     */
     [[nodiscard]] bool IsAbsolute() const;
+
+    /**
+     * @brief Gets the number of node names which make up the path. Subnames (see GetSubNameCount) are not included.
+     *  For example, "Path2D/PathFollow2D/Sprite2D" has 3 names.
+     *
+     * @returns number of node names.
+     */
     [[nodiscard]] ulong GetNameCount() const;
+
+    /**
+     * @brief Gets the node name indicated by idx (0 to GetNameCount - 1).
+     * @params
+     *  idx[int]: Name index of list of names.
+     *
+     * @returns a String of indexed name or an empty String for an invalid index.
+     */
     [[nodiscard]] String GetName(int idx) const;
+
+    /**
+     * @brief Gets the number of resource or property names ("subnames") in the path. Each subname is listed
+     *  after a colon character (:) in the node path.
+     *
+     * @returns number of node subnames.
+     */
     [[nodiscard]] ulong GetSubNameCount() const;
+
+    /**
+     * @brief Gets the resource or property name indicated by idx (0 to GetSubnameCount).
+     * @params
+     *  idx[int]: Name index of list of subnames.
+     *
+     * @returns a String of indexed subname or an empty String for an invalid index.
+     */
     [[nodiscard]] String GetSubName(int idx) const;
+
+    /**
+     * @brief Gets the list of node names which make up the path.
+     *
+     * @returns a list (std::vector<String>) of node names.
+     */
     [[nodiscard]] std::vector<String> GetNames() const;
+
+    /**
+     * @brief Gets the list of resource or property names in the path.
+     *
+     * @returns a list (std::vector<String>) of subnames.
+     */
     [[nodiscard]] std::vector<String> GetSubNames() const;
+
+    /**
+     * @brief Gets all paths concatenated with a slash character (/) as separator without subnames.
+     *
+     * @returns a String of path.
+     */
     [[nodiscard]] String GetConcatenatedNames() const;
+
+    /**
+    * @brief Gets all subnames concatenated with a colon character (:) as separator,
+    *  i.e. the right side of the first colon in a node path.
+    *
+    * @returns a String of resource of property path.
+    */
     [[nodiscard]] String GetConcatenatedSubNames() const;
 
+    /**
+     * @brief Gets a node path with a colon character (:) prepended,
+     *  transforming it to a pure property path with no node name (defaults to resolving from the current node).
+     *
+     * @returns a String of property path.
+     */
     [[nodiscard]] NodePath GetAsPropertyPath() const;
+
     explicit operator String() const;
+
+    /**
+     * @brief The node path is empty if both node names and subnames are empty.
+     *
+     * @returns true if node path is empty, otherwise false.
+     */
     [[nodiscard]] bool IsEmpty() const;
 
     bool operator==(const NodePath &path) const;
     bool operator!=(const NodePath &path) const;
     NodePath& operator=(const NodePath &path) = default;
 
+    /**
+     * @brief Simplifies a node path with "." or ".." noting current node name or last node name respectively.
+     *  This removes these two separators and replaces the original node path with a pure path.
+     */
     void Simplify();
+
+    /**
+     * @brief Gets a simplified node path for the original path.
+     *
+     * @returns a new NodePath and preserves the original one.
+     */
     [[nodiscard]] NodePath Simplified() const;
 
 private:

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -3,6 +3,7 @@
  * Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
  * This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License.
  * This file is created by Qiqi Wu, 22-11-6
+ * This file is modified by Zikun Yu, 23-1-15
 */
 
 #pragma once
@@ -19,10 +20,10 @@ using StringList = QStringList;
 
 class NodePath {
 public:
-    NodePath(const std::vector<String>& path, bool absolute);
-    NodePath(const std::vector<String>& path, const std::vector<String>& subpath, bool absolute);
-    NodePath(const NodePath& path);
-    explicit NodePath(const String& path);
+    NodePath(const std::vector<String> &path, bool absolute);
+    NodePath(const std::vector<String> &path, const std::vector<String> &subpath, bool absolute);
+    NodePath(const NodePath &path);
+    explicit NodePath(const String &path);
     NodePath() = default;
     ~NodePath() = default;
 
@@ -33,14 +34,16 @@ public:
     [[nodiscard]] String GetSubName(int idx) const;
     [[nodiscard]] std::vector<String> GetNames() const;
     [[nodiscard]] std::vector<String> GetSubNames() const;
-    void Simplify();
-    NodePath Simplified() const;
-    bool IsEmpty() const;
-    operator String() const;
 
-    NodePath& operator=(const NodePath &path) = default;
+    explicit operator String() const;
+    [[nodiscard]] bool IsEmpty() const;
+
     bool operator==(const NodePath &path) const;
     bool operator!=(const NodePath &path) const;
+    NodePath& operator=(const NodePath &path) = default;
+
+    void Simplify();
+    [[nodiscard]] NodePath Simplified() const;
 
 private:
     std::vector<String> path_;

--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include "gobot/core/types.hpp"
+#include <vector>
+
 
 namespace gobot {
 
@@ -15,7 +17,27 @@ class NodePath {
 public:
     NodePath();
 
+    NodePath(const std::vector<String> &path, bool absolute);
+
+    NodePath(const NodePath& path) = default;
+
+    NodePath& operator=(const NodePath &path) = default;
+
+    NodePath(const String& path);
+
     bool IsAbsolute() const;
+
+    void Simplify();
+
+    NodePath Simplified() const;
+
+    bool IsEmpty() const;
+
+    operator String() const;
+
+    bool operator==(const NodePath &path) const;
+
+    bool operator!=(const NodePath &path) const;
 
 private:
     std::vector<String> path_;

--- a/include/gobot/scene/view_port.hpp
+++ b/include/gobot/scene/view_port.hpp
@@ -1,0 +1,20 @@
+/* The gobot is a robot simulation platform. 
+ * Copyright(c) 2021-2023, RobSimulatorGroup, Qiqi Wu<1258552199@qq.com>.
+ * Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+ * This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License.
+ * This file is created by Qiqi Wu, 23-1-14
+*/
+
+#pragma once
+
+#include "gobot/scene/node.hpp"
+
+namespace gobot {
+
+class ViewPort : public Node {
+    GOBCLASS(ViewPort, Node)
+public:
+
+};
+
+}

--- a/src/gobot/core/io/object_serialize.cpp
+++ b/src/gobot/core/io/object_serialize.cpp
@@ -235,7 +235,7 @@
 //
 //    to_json_recursively(obj, writer);
 //
-//    return sb.GetString();
+//    return sb.GeStrData();
 //}
 //
 //core::Json ObjectToJson(rttr::instance obj);

--- a/src/gobot/scene/node.cpp
+++ b/src/gobot/scene/node.cpp
@@ -13,4 +13,8 @@ Node::Node() {
 
 }
 
+void Node::Notification(NotificationType notification) {
+
+}
+
 }

--- a/src/gobot/scene/node_path.cpp
+++ b/src/gobot/scene/node_path.cpp
@@ -196,7 +196,7 @@ void NodePath::SetStrData(const String& str) {
     *this = NodePath(str);
 }
 
-String NodePath::GeStrData() {
+String NodePath::GetStrData() {
     return this->operator String();
 }
 
@@ -220,7 +220,7 @@ GOBOT_REGISTRATION {
             .property_readonly("simplified", &NodePath::Simplified)
             .property_readonly("to_string", &NodePath::operator String)
 
-            .property("str_data", &NodePath::GeStrData, &NodePath::SetStrData)
+            .property("str_data", &NodePath::GetStrData, &NodePath::SetStrData)
 
             .method("get_name", &NodePath::GetName)
             .method("get_subname", &NodePath::GetSubName)

--- a/src/gobot/scene/node_path.cpp
+++ b/src/gobot/scene/node_path.cpp
@@ -10,6 +10,40 @@
 
 namespace gobot {
 
+static constexpr Qt::SplitBehaviorFlags FlagSkipEmptyParts = Qt::SkipEmptyParts;
+
+NodePath::NodePath(const String &path) {
+    if (!path.length()) return;
+
+    String raw_path = path;
+    std::vector<String> path_list;
+
+    int subpath_pos = path.indexOf(u':');
+    if (subpath_pos == 0) {
+        // exception: invalid path
+    }
+    if (subpath_pos > 0) {
+        path_list = raw_path.split(u':', FlagSkipEmptyParts).toVector().toStdVector();
+        if (!path_list.empty()) {
+            this->subpath_ = std::vector(path_list.begin() + 1, path_list.end());
+            raw_path = path_list.front();
+        }
+    } else {// subpath_pos == -1, no subpath exists
+        if (raw_path.isEmpty()) {
+            // exception: invvalid path
+        }
+        this->subpath_ = std::vector<String>();
+    }
+
+    bool absolute = (raw_path.front() == u'/');
+    if (absolute) {
+        raw_path.remove(0, 1);
+    }
+    this->path_ = raw_path.split(u'/', FlagSkipEmptyParts).toVector().toStdVector();
+    if (this->path_.empty())
+        this->path_.push_back(raw_path);
+}
+
 NodePath::NodePath() {
 }
 

--- a/src/gobot/scene/node_path.cpp
+++ b/src/gobot/scene/node_path.cpp
@@ -8,22 +8,22 @@
 
 
 #include "gobot/scene/node_path.hpp"
+#include "gobot/core/registration.hpp"
 
 namespace gobot {
 
 template <typename T>
 using Vector = QVector<T>;
-static constexpr Qt::SplitBehaviorFlags FlagSkipEmptyParts = Qt::SkipEmptyParts;
 
 NodePath::NodePath(const std::vector<String> &path, bool absolute) {
-    data_.path_ = path;
-    data_.absolute_ = absolute;
+    data_.path = path;
+    data_.absolute = absolute;
 }
 
 NodePath::NodePath(const std::vector<String> &path, const std::vector<String> &subpath, bool absolute) {
-    data_.path_ = path;
-    data_.subpath_ = subpath;
-    data_.absolute_ = absolute;
+    data_.path = path;
+    data_.subpath = subpath;
+    data_.absolute = absolute;
 }
 
 NodePath::NodePath(const String &path) {
@@ -36,7 +36,7 @@ NodePath::NodePath(const String &path) {
     int subpath_pos = path.indexOf(u':');
 
     if (subpath_pos >= 0) {
-        subpath_list = raw_path.split(u':', FlagSkipEmptyParts).toVector();
+        subpath_list = raw_path.split(u':', S_FLAG_SKIP_EMPTY_PARTS).toVector();
         if (subpath_pos > 0) {
             raw_path = subpath_list.front();
             subpath_list.pop_front();
@@ -51,87 +51,87 @@ NodePath::NodePath(const String &path) {
         path_list = Vector<String>();
     } else {
         if (is_absolute) raw_path.remove(0, 1);
-        path_list = raw_path.split(u'/', FlagSkipEmptyParts).toVector();
+        path_list = raw_path.split(u'/', S_FLAG_SKIP_EMPTY_PARTS).toVector();
         if (path_list.isEmpty())
             path_list = Vector<String>(raw_path.size(), raw_path);
     }
 
-    data_.absolute_ = is_absolute;
-    data_.path_ = std::vector<String>(path_list.begin(), path_list.end());
-    data_.subpath_ = std::vector<String>(subpath_list.begin(), subpath_list.end());
+    data_.absolute = is_absolute;
+    data_.path = std::move(std::vector<String>(path_list.begin(), path_list.end()));
+    data_.subpath = std::move(std::vector<String>(subpath_list.begin(), subpath_list.end()));
 }
 
 bool NodePath::IsAbsolute() const {
-    return data_.absolute_;
+    return data_.absolute;
 }
 
 ulong NodePath::GetNameCount() const {
-    return data_.path_.size();
+    return data_.path.size();
 }
 
 String NodePath::GetName(int idx) const {
-    ERR_FAIL_COND_V(data_.path_.empty(), String());
-    ERR_FAIL_INDEX_V(idx, data_.path_.size(), String());
-    return data_.path_[idx];
+    ERR_FAIL_COND_V(data_.path.empty(), String());
+    ERR_FAIL_INDEX_V(idx, data_.path.size(), String());
+    return data_.path[idx];
 }
 
 ulong NodePath::GetSubNameCount() const {
-    return data_.subpath_.size();
+    return data_.subpath.size();
 }
 
 String NodePath::GetSubName(int idx) const {
-    ERR_FAIL_COND_V(data_.subpath_.empty(), String());
-    ERR_FAIL_INDEX_V(idx, data_.subpath_.size(), String());
-    return data_.subpath_[idx];
+    ERR_FAIL_COND_V(data_.subpath.empty(), String());
+    ERR_FAIL_INDEX_V(idx, data_.subpath.size(), String());
+    return data_.subpath[idx];
 }
 
 std::vector<String> NodePath::GetNames() const {
-    return data_.path_;
+    return data_.path;
 }
 
 std::vector<String> NodePath::GetSubNames() const {
-    return data_.subpath_;
+    return data_.subpath;
 }
 
 String NodePath::GetConcatenatedNames() const {
     ERR_FAIL_COND_V(IsEmpty(), String());
 
-    if (data_.concatenated_path_.isEmpty()) {
+    if (data_.concatenated_path.isEmpty()) {
         String concatenated;
-        std::vector<String> path = data_.path_;
+        std::vector<String> path = data_.path;
 
-        if (data_.absolute_) concatenated += "/";
+        if (data_.absolute) concatenated += "/";
         for (int i = 0; i < path.size(); ++i) {
             concatenated += i == 0 ? path[i] : "/" + path[i];
         }
-        data_.concatenated_path_ = concatenated;
+        data_.concatenated_path = concatenated;
     }
 
-    return data_.concatenated_path_;
+    return data_.concatenated_path;
 }
 
 String NodePath::GetConcatenatedSubNames() const {
     ERR_FAIL_COND_V(IsEmpty(), String());
 
-    if (data_.concatenated_subpath_.isEmpty()) {
+    if (data_.concatenated_subpath.isEmpty()) {
         String concatenated;
-        std::vector<String> subpath = data_.subpath_;
+        std::vector<String> subpath = data_.subpath;
         for (int i = 0; i < subpath.size(); ++i) {
             concatenated += i == 0 ? subpath[i] : ":" + subpath[i];
         }
-        data_.concatenated_subpath_ = concatenated;
+        data_.concatenated_subpath = concatenated;
     }
 
-    return data_.concatenated_subpath_;
+    return data_.concatenated_subpath;
 }
 
 NodePath NodePath::GetAsPropertyPath() const {
-    if (IsEmpty() || data_.path_.empty()) return *this;
+    if (IsEmpty() || data_.path.empty()) return *this;
 
-    std::vector<String> new_path = data_.subpath_;
-    String initial_subname = data_.path_[0];
-    for (int i = 1; i < data_.path_.size(); ++i) {
-        initial_subname += "/" + data_.path_[i];
+    std::vector<String> new_path = data_.subpath;
+    String initial_subname = data_.path[0];
+    for (int i = 1; i < data_.path.size(); ++i) {
+        initial_subname += "/" + data_.path[i];
     }
     new_path.insert(new_path.begin(), initial_subname);
 
@@ -142,14 +142,14 @@ NodePath::operator String() const {
     if (IsEmpty()) return {};
 
     String ret;
-    if (data_.absolute_) ret = "/";
+    if (data_.absolute) ret = "/";
 
-    for (int i = 0; i < data_.path_.size(); ++i) {
+    for (int i = 0; i < data_.path.size(); ++i) {
         if (i > 0) ret += "/";
-        ret += data_.path_[i];
+        ret += data_.path[i];
     }
 
-    for (const auto & str : data_.subpath_) {
+    for (const auto & str : data_.subpath) {
         ret += ":" + str;
     }
 
@@ -157,27 +157,27 @@ NodePath::operator String() const {
 }
 
 bool NodePath::IsEmpty() const {
-    return data_.path_.empty() && data_.subpath_.empty();
+    return data_.path.empty() && data_.subpath.empty();
 }
 
 bool NodePath::operator==(const NodePath &path) const {
     if (IsEmpty() != path.IsEmpty()) return false;
 
-    if (data_.absolute_ != path.data_.absolute_) return false;
+    if (data_.absolute != path.data_.absolute) return false;
 
-    if (data_.path_.size() != path.data_.path_.size()) return false;
+    if (data_.path.size() != path.data_.path.size()) return false;
 
-    if (data_.subpath_.size() != path.data_.subpath_.size()) return false;
+    if (data_.subpath.size() != path.data_.subpath.size()) return false;
 
-    if (!data_.path_.empty()) {
-        for (int i = 0; i < data_.path_.size(); ++i) {
-            if (data_.path_[i] != path.data_.path_[i]) return false;
+    if (!data_.path.empty()) {
+        for (int i = 0; i < data_.path.size(); ++i) {
+            if (data_.path[i] != path.data_.path[i]) return false;
         }
     }
 
-    if (!data_.subpath_.empty()) {
-        for (int i = 0; i < data_.subpath_.size(); ++i) {
-            if (data_.subpath_[i] != path.data_.subpath_[i]) return false;
+    if (!data_.subpath.empty()) {
+        for (int i = 0; i < data_.subpath.size(); ++i) {
+            if (data_.subpath[i] != path.data_.subpath[i]) return false;
         }
     }
 
@@ -191,18 +191,18 @@ bool NodePath::operator!=(const NodePath &path) const {
 void NodePath::Simplify() {
     if (IsEmpty()) return;
 
-    for (int i = 0; i < data_.path_.size(); ++i) {
-        if (data_.path_.size() == 1) break;
+    for (int i = 0; i < data_.path.size(); ++i) {
+        if (data_.path.size() == 1) break;
 
-        if (data_.path_[i] == ".") {
-            data_.path_.erase(data_.path_.begin() + i);
+        if (data_.path[i] == ".") {
+            data_.path.erase(data_.path.begin() + i);
             i--;
-        } else if (i > 0 && data_.path_[i] == ".." && data_.path_[i - 1] != "." && data_.path_[i - 1] != "..") {
+        } else if (i > 0 && data_.path[i] == ".." && data_.path[i - 1] != "." && data_.path[i - 1] != "..") {
             // remove path_[i - 1] and path_[i]
-            data_.path_.erase(data_.path_.begin() + i - 1, data_.path_.begin() + i + 1);
+            data_.path.erase(data_.path.begin() + i - 1, data_.path.begin() + i + 1);
             i -= 2;
-            if (data_.path_.empty()) {
-                data_.path_.emplace_back(".");
+            if (data_.path.empty()) {
+                data_.path.emplace_back(".");
                 break;
             }
         }
@@ -216,4 +216,29 @@ NodePath NodePath::Simplified() const {
     return np;
 }
 
-}
+} // End of namespace gobot
+
+GOBOT_REGISTRATION {
+
+    Class_<NodePath>("NodePath")
+            .constructor<const std::vector<String>&, bool>()
+            .constructor<const std::vector<String>&, const std::vector<String>, bool>()
+            .constructor<const NodePath&>()
+            .constructor<const String&>()
+
+            .property_readonly("is_absolute", &NodePath::IsAbsolute)
+            .property_readonly("is_empty", &NodePath::IsEmpty)
+            .property_readonly("name_count", &NodePath::GetNameCount)
+            .property_readonly("subname_count", &NodePath::GetSubNameCount)
+            .property_readonly("name_list", &NodePath::GetNames)
+            .property_readonly("subname_list", &NodePath::GetSubNames)
+            .property_readonly("name_path", &NodePath::GetConcatenatedNames)
+            .property_readonly("subname_path", &NodePath::GetConcatenatedSubNames)
+            .property_readonly("to_property_path", &NodePath::GetAsPropertyPath)
+            .property_readonly("simplified", &NodePath::Simplified)
+
+            .method("get_name", &NodePath::GetName)
+            .method("get_subname", &NodePath::GetSubName)
+            .method("simplify", &NodePath::Simplify)
+            ;
+};

--- a/src/gobot/scene/node_path.cpp
+++ b/src/gobot/scene/node_path.cpp
@@ -36,7 +36,7 @@ NodePath::NodePath(const String &path) {
     int subpath_pos = path.indexOf(u':');
 
     if (subpath_pos >= 0) {
-        subpath_list = raw_path.split(u':', S_FLAG_SKIP_EMPTY_PARTS).toVector();
+        subpath_list = raw_path.split(u':', s_split_behavior_flags).toVector();
         if (subpath_pos > 0) {
             raw_path = subpath_list.front();
             subpath_list.pop_front();
@@ -51,7 +51,7 @@ NodePath::NodePath(const String &path) {
         path_list = Vector<String>();
     } else {
         if (is_absolute) raw_path.remove(0, 1);
-        path_list = raw_path.split(u'/', S_FLAG_SKIP_EMPTY_PARTS).toVector();
+        path_list = raw_path.split(u'/', s_split_behavior_flags).toVector();
         if (path_list.isEmpty())
             path_list = Vector<String>(raw_path.size(), raw_path);
     }
@@ -192,15 +192,20 @@ NodePath NodePath::Simplified() const {
     return np;
 }
 
+void NodePath::SetStrData(const String& str) {
+    *this = NodePath(str);
+}
+
+String NodePath::GeStrData() {
+    return this->operator String();
+}
+
+
 } // End of namespace gobot
 
 GOBOT_REGISTRATION {
 
     Class_<NodePath>("NodePath")
-            .constructor<const std::vector<String>&, bool>()(CtorAsObject)
-            .constructor<const std::vector<String>&, const std::vector<String>, bool>()(CtorAsObject)
-            .constructor<const NodePath&>()(CtorAsObject)
-            .constructor<const String&>()(CtorAsObject)
             .constructor()(CtorAsObject)
 
             .property_readonly("is_absolute", &NodePath::IsAbsolute)
@@ -213,6 +218,9 @@ GOBOT_REGISTRATION {
             .property_readonly("subname_path", &NodePath::GetConcatenatedSubNames)
             .property_readonly("to_property_path", &NodePath::GetAsPropertyPath)
             .property_readonly("simplified", &NodePath::Simplified)
+            .property_readonly("to_string", &NodePath::operator String)
+
+            .property("str_data", &NodePath::GeStrData, &NodePath::SetStrData)
 
             .method("get_name", &NodePath::GetName)
             .method("get_subname", &NodePath::GetSubName)

--- a/src/gobot/scene/node_path.cpp
+++ b/src/gobot/scene/node_path.cpp
@@ -27,10 +27,7 @@ NodePath::NodePath(const std::vector<String> &path, const std::vector<String> &s
 }
 
 NodePath::NodePath(const String &path) {
-    if (!path.length()) {
-        LOG_ERROR("Invalid NodePath {}.", path);
-        return;
-    }
+    if (!path.length()) return;
 
     String raw_path = path;
     bool is_absolute = (raw_path.front() == u'/');
@@ -73,14 +70,8 @@ ulong NodePath::GetNameCount() const {
 }
 
 String NodePath::GetName(int idx) const {
-    if (idx < 0 || idx >= data_.path_.size()) {
-        LOG_ERROR("Invalid index {}.", idx);
-        return {};
-    }
-    if (data_.path_.empty()) {
-        LOG_ERROR("Empty NodePath {}.");
-        return {};
-    }
+    ERR_FAIL_COND_V(data_.path_.empty(), String());
+    ERR_FAIL_INDEX_V(idx, data_.path_.size(), String());
     return data_.path_[idx];
 }
 
@@ -89,14 +80,8 @@ ulong NodePath::GetSubNameCount() const {
 }
 
 String NodePath::GetSubName(int idx) const {
-    if (idx < 0 || idx >= data_.subpath_.size()) {
-        LOG_ERROR("Invalid index {}.", idx);
-        return {};
-    }
-    if (data_.subpath_.empty()) {
-        LOG_ERROR("Void NodePath.");
-        return {};
-    }
+    ERR_FAIL_COND_V(data_.subpath_.empty(), String());
+    ERR_FAIL_INDEX_V(idx, data_.subpath_.size(), String());
     return data_.subpath_[idx];
 }
 
@@ -109,7 +94,7 @@ std::vector<String> NodePath::GetSubNames() const {
 }
 
 String NodePath::GetConcatenatedNames() const {
-    if (IsEmpty()) LOG_ERROR("Empty NodePath.");
+    ERR_FAIL_COND_V(IsEmpty(), String());
 
     if (data_.concatenated_path_.isEmpty()) {
         String concatenated;
@@ -126,7 +111,7 @@ String NodePath::GetConcatenatedNames() const {
 }
 
 String NodePath::GetConcatenatedSubNames() const {
-    if (IsEmpty()) LOG_ERROR("Empty NodePath.");
+    ERR_FAIL_COND_V(IsEmpty(), String());
 
     if (data_.concatenated_subpath_.isEmpty()) {
         String concatenated;

--- a/src/gobot/scene/node_path.cpp
+++ b/src/gobot/scene/node_path.cpp
@@ -10,45 +10,155 @@
 
 namespace gobot {
 
+template <typename T>
+using Vector = QVector<T>;
 static constexpr Qt::SplitBehaviorFlags FlagSkipEmptyParts = Qt::SkipEmptyParts;
 
-NodePath::NodePath(const String &path) {
-    if (!path.length()) return;
+NodePath::NodePath(const std::vector<String>& path, bool absolute) {
+    subpath_ = std::vector<String>();
+    absolute_ = absolute;
+
+    if (path.empty()) {
+        path_ = std::vector<String>();
+        valid_ = false;
+        return;
+    }
+
+    path_ = path;
+    valid_ = true;
+}
+
+NodePath::NodePath(const std::vector<String> &path, const std::vector<String> &subpath, bool absolute) {
+    absolute_ = absolute;
+
+    if (path.empty() || subpath.empty()) {
+        path_ = std::vector<String>();
+        subpath_ = std::vector<String>();
+        return;
+    }
+
+    path_ = path;
+    subpath_ = subpath;
+    valid_ = true;
+
+}
+
+NodePath::NodePath(const NodePath &path) {
+    if (!path.valid_) {
+        path_ = std::vector<String>();
+        subpath_ = std::vector<String>();
+        return;
+    }
+
+    path_ = path.path_;
+    subpath_ = path.subpath_;
+    absolute_ = path.absolute_;
+}
+
+NodePath::NodePath(const String& path) {
+    bool is_valid = true;
+    if (!path.length()) {
+        LOG_ERROR("Invalid NodePath {}.", path);
+        is_valid = false;
+    }
 
     String raw_path = path;
-    std::vector<String> path_list;
+    bool is_absolute = (raw_path.front() == u'/');
+    Vector<String> path_list;
+    Vector<String> subpath_list;
 
     int subpath_pos = path.indexOf(u':');
-    if (subpath_pos == 0) {
-        // exception: invalid path
+    if (is_valid && subpath_pos == 0) {
+        LOG_ERROR("Invalid NodePath {}.", path);
+        is_valid = false;
     }
-    if (subpath_pos > 0) {
-        path_list = raw_path.split(u':', FlagSkipEmptyParts).toVector().toStdVector();
+
+    if (is_valid && subpath_pos > 0) {
+        path_list = raw_path.split(u':', FlagSkipEmptyParts).toVector();
         if (!path_list.empty()) {
-            this->subpath_ = std::vector(path_list.begin() + 1, path_list.end());
+            subpath_list = Vector<String>(path_list.begin() + 1, path_list.end());
             raw_path = path_list.front();
         }
     } else {// subpath_pos == -1, no subpath exists
         if (raw_path.isEmpty()) {
-            // exception: invvalid path
+            LOG_ERROR("Invalid NodePath {}.", path);
+            is_valid = false;
         }
-        this->subpath_ = std::vector<String>();
     }
 
-    bool absolute = (raw_path.front() == u'/');
-    if (absolute) {
-        raw_path.remove(0, 1);
-    }
-    this->path_ = raw_path.split(u'/', FlagSkipEmptyParts).toVector().toStdVector();
-    if (this->path_.empty())
-        this->path_.push_back(raw_path);
-}
+    if (is_valid) {
+        if (is_absolute) {
+            raw_path.remove(0, 1);
+        }
+        path_list = raw_path.split(u'/', FlagSkipEmptyParts).toVector();
+        if (path_list.empty())
+            path_list.push_back(raw_path);
 
-NodePath::NodePath() {
+        path_ = std::vector<String>(path_list.begin(), path_list.end());
+        subpath_ = std::vector<String>(subpath_list.begin(), subpath_list.end());
+    } else {
+        path_ = std::vector<String>();
+        subpath_ = std::vector<String>();
+    }
+    valid_ = is_valid;
+    absolute_ = is_absolute;
 }
 
 bool NodePath::IsAbsolute() const {
     return absolute_;
 }
+
+ulong NodePath::GetNameCount() const {
+    if (!valid_) {
+        return 0;
+    }
+    return path_.size();
+}
+
+String NodePath::GetName(int idx) const {
+    if (idx < 0 || idx >= path_.size()) {
+        LOG_ERROR("Invalid index {}.", idx);
+        return {};
+    }
+    if (!valid_ || path_.empty()) {
+        LOG_ERROR("Void NodePath {}.");
+        return {};
+    }
+    return path_[idx];
+}
+
+ulong NodePath::GetSubNameCount() const {
+    if (!valid_) {
+        return 0;
+    }
+    return subpath_.size();
+}
+
+String NodePath::GetSubName(int idx) const {
+    if (idx < 0 || idx >= subpath_.size()) {
+        LOG_ERROR("Invalid index {}.", idx);
+        return {};
+    }
+    if (!valid_ || subpath_.empty()) {
+        LOG_ERROR("Void NodePath {}.");
+        return {};
+    }
+    return subpath_[idx];
+}
+
+std::vector<String> NodePath::GetNames() const {
+    if (valid_) {
+        return path_;
+    }
+    return {};
+}
+
+std::vector<String> NodePath::GetSubNames() const {
+    if (valid_) {
+        return subpath_;
+    }
+    return {};
+}
+
 
 }

--- a/src/gobot/scene/node_path.cpp
+++ b/src/gobot/scene/node_path.cpp
@@ -160,30 +160,6 @@ bool NodePath::IsEmpty() const {
     return data_.path.empty() && data_.subpath.empty();
 }
 
-bool NodePath::operator==(const NodePath &path) const {
-    if (IsEmpty() != path.IsEmpty()) return false;
-
-    if (data_.absolute != path.data_.absolute) return false;
-
-    if (data_.path.size() != path.data_.path.size()) return false;
-
-    if (data_.subpath.size() != path.data_.subpath.size()) return false;
-
-    if (!data_.path.empty()) {
-        for (int i = 0; i < data_.path.size(); ++i) {
-            if (data_.path[i] != path.data_.path[i]) return false;
-        }
-    }
-
-    if (!data_.subpath.empty()) {
-        for (int i = 0; i < data_.subpath.size(); ++i) {
-            if (data_.subpath[i] != path.data_.subpath[i]) return false;
-        }
-    }
-
-    return true;
-}
-
 bool NodePath::operator!=(const NodePath &path) const {
     return !(*this == path);
 }
@@ -221,10 +197,11 @@ NodePath NodePath::Simplified() const {
 GOBOT_REGISTRATION {
 
     Class_<NodePath>("NodePath")
-            .constructor<const std::vector<String>&, bool>()
-            .constructor<const std::vector<String>&, const std::vector<String>, bool>()
-            .constructor<const NodePath&>()
-            .constructor<const String&>()
+            .constructor<const std::vector<String>&, bool>()(CtorAsObject)
+            .constructor<const std::vector<String>&, const std::vector<String>, bool>()(CtorAsObject)
+            .constructor<const NodePath&>()(CtorAsObject)
+            .constructor<const String&>()(CtorAsObject)
+            .constructor()(CtorAsObject)
 
             .property_readonly("is_absolute", &NodePath::IsAbsolute)
             .property_readonly("is_empty", &NodePath::IsEmpty)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,3 +31,5 @@ endmacro()
 package_add_test(test_ref_counted core/test_ref_counted.cpp )
 package_add_test(test_registration core/test_registration.cpp )
 package_add_test(test_resource core/test_resource.cpp )
+
+package_add_test(test_node_path scene/test_node_path.cpp)

--- a/tests/scene/test_node_path.cpp
+++ b/tests/scene/test_node_path.cpp
@@ -20,8 +20,125 @@ public:
 
 }
 
-TEST(TestNodePath, rel_path) {
-    const gobot::NodePath node_path_relative = gobot::NodePath("/Path2D/PathFollow2D/Sprite2D:position:x");
+TEST(TestNodePath, relative_path) {
+    const gobot::NodePath node_path_relative = gobot::NodePath("Path2D/PathFollow2D/Sprite2D:position:x");
 
-    ASSERT_TRUE(node_path_relative.IsAbsolute() == true);
+    // The constructor should return the same node path.
+    ASSERT_TRUE(
+            gobot::NodePath(node_path_relative.GetNames(),
+                            node_path_relative.GetSubNames(),
+                            false) ==
+            node_path_relative);
+    // The returned property path should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetAsPropertyPath() ==
+        gobot::NodePath(":Path2D/PathFollow2D/Sprite2D:position:x"));
+    // The returned concatenated names should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetConcatenatedNames() == "Path2D/PathFollow2D/Sprite2D");
+    // The returned concatenated subnames should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetConcatenatedSubNames() == "position:x");
+
+    // The returned name at index 0 should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetName(0) == "Path2D");
+    // The returned name at index 1 should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetName(1) == "PathFollow2D");
+    // The returned name at index 2 should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetName(2) == "Sprite2D");
+LOG_OFF;
+    // The returned name at invalid index 3 should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetName(3) == "");
+    // The returned name at invalid index -1 should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetName(-1) == "");
+LOG_ON;
+    // The returned number of names should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetNameCount() == 3);
+
+    // The returned subname at index 0 should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetSubName(0) == "position");
+    // The returned subname at index 1 should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetSubName(1) == "x");
+LOG_OFF;
+    // The returned subname at invalid index 2 should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetSubName(2) == "");
+    // The returned subname at invalid index -1 should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetSubName(-1) == "");
+LOG_ON;
+    // The returned number of subnames should match the expected value.
+    ASSERT_TRUE(node_path_relative.GetSubNameCount() == 2);
+
+    // The node path should be considered relative.
+    ASSERT_TRUE(node_path_relative.IsAbsolute() == false);
+    // The node path shouldn't be considered empty.
+    ASSERT_TRUE(node_path_relative.IsEmpty() == false);
+}
+
+TEST(TestNodePath, absolute_path) {
+    const gobot::NodePath node_path_absolute = gobot::NodePath("/root/Sprite2D");
+
+    // The constructor should return the same node path.
+    ASSERT_TRUE(gobot::NodePath(node_path_absolute.GetNames(), true) == node_path_absolute);
+    // The returned property path should match the expected value.
+    ASSERT_TRUE(node_path_absolute.GetAsPropertyPath() == gobot::NodePath(":root/Sprite2D"));
+    // The returned concatenated names should match the expected value.
+    ASSERT_TRUE(node_path_absolute.GetConcatenatedNames() == "/root/Sprite2D");
+    // The returned concatenated subnames should match the expected value.
+    ASSERT_TRUE(node_path_absolute.GetConcatenatedSubNames() == "");
+
+    // The returned name at index 0 should match the expected value.
+    ASSERT_TRUE(node_path_absolute.GetName(0) == "root");
+    // The returned name at index 1 should match the expected value.
+    ASSERT_TRUE(node_path_absolute.GetName(1) == "Sprite2D");
+LOG_OFF;
+    // The returned name at invalid index 2 should match the expected value.
+    ASSERT_TRUE(node_path_absolute.GetName(2) == "");
+    // The returned name at invalid index -1 should match the expected value.
+    ASSERT_TRUE(node_path_absolute.GetName(-1) == "");
+LOG_ON;
+    // The returned number of names should match the expected value.
+    ASSERT_TRUE(node_path_absolute.GetNameCount() == 2);
+    // The returned number of subnames should match the expected value.
+    ASSERT_TRUE(node_path_absolute.GetSubNameCount() == 0);
+
+    // The node path should be considered absolute.
+    ASSERT_TRUE(node_path_absolute.IsAbsolute() == true);
+    // The node path shouldn't be considered empty.
+    ASSERT_TRUE(node_path_absolute.IsEmpty() == false);
+}
+
+TEST(TestNodePath, empty_path) {
+    const gobot::NodePath node_path_empty = gobot::NodePath();
+
+    // The constructor should return the same node path.
+    ASSERT_TRUE(
+            gobot::NodePath(node_path_empty.GetNames(),
+                            node_path_empty.GetSubNames(),
+                            false) ==
+                    node_path_empty);
+    // The returned property path should match the expected value.
+    ASSERT_TRUE(node_path_empty.GetAsPropertyPath() == gobot::NodePath());
+LOG_OFF;
+    // The returned concatenated names should match the expected value.
+    ASSERT_TRUE(node_path_empty.GetConcatenatedNames() == "");
+    // The returned concatenated subnames should match the expected value.
+    ASSERT_TRUE(node_path_empty.GetConcatenatedSubNames() == "");
+LOG_ON;
+
+    // The returned number of names should match the expected value.
+    ASSERT_TRUE(node_path_empty.GetNameCount() == 0);
+    // The returned number of subnames should match the expected value.
+    ASSERT_TRUE(node_path_empty.GetSubNameCount() == 0);
+
+    // The node path shouldn't be considered absolute.
+    ASSERT_TRUE(node_path_empty.IsAbsolute() == false);
+    // The node path should be considered empty.
+    ASSERT_TRUE(node_path_empty.IsEmpty() == true);
+}
+
+TEST(TestNodePath, complex_path) {
+    const gobot::NodePath node_path_complex = gobot::NodePath("Path2D/./PathFollow2D/../Sprite2D:position:x");
+    const gobot::NodePath node_path_simplified = node_path_complex.Simplified();
+
+    // The returned concatenated names should match the expected value.
+    ASSERT_TRUE(node_path_simplified.GetConcatenatedNames() == "Path2D/Sprite2D");
+    // The returned concatenated subnames should match the expected value.
+    ASSERT_TRUE(node_path_simplified.GetConcatenatedSubNames() == "position:x");
 }

--- a/tests/scene/test_node_path.cpp
+++ b/tests/scene/test_node_path.cpp
@@ -133,3 +133,21 @@ TEST(TestNodePath, complex_path) {
     // The returned concatenated subnames should match the expected value.
     ASSERT_TRUE(node_path_simplified.GetConcatenatedSubNames() == "position:x");
 }
+
+TEST(TestNodePath, test_type) {
+    gobot::Variant var = gobot::NodePath("/home/gobot");
+    auto node_path = var.convert<gobot::NodePath>();
+    ASSERT_TRUE(node_path.operator gobot::
+    String() == gobot::String("/home/gobot"));
+
+    auto prop = var.get_type().get_property("str_data");
+    ASSERT_TRUE(prop.get_value(var).to_string() == "/home/gobot");
+
+    auto type = gobot::Type::get_by_name("NodePath");
+    auto var2 = type.create();
+    prop.set_value(var2, gobot::String("/home/gobot"));
+    ASSERT_TRUE(prop.get_value(var2).to_string() == "/home/gobot");
+
+    auto node_path2 = var2.convert<gobot::NodePath>();
+    ASSERT_TRUE(node_path2.operator gobot::String() == gobot::String("/home/gobot"));
+}

--- a/tests/scene/test_node_path.cpp
+++ b/tests/scene/test_node_path.cpp
@@ -1,0 +1,28 @@
+/* The gobot is a robot simulation platform.
+ * Copyright(c) 2021-2022, RobSimulatorGroup, Qiqi Wu<1258552199@qq.com>.
+ * Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+ * This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License.
+ * This file is created by Qiqi Wu, 22-11-27
+*/
+
+#include <gtest/gtest.h>
+
+//#include <gobot/log.hpp>
+#include <gobot/core/types.hpp>
+#include <gobot/scene/node_path.hpp>
+
+namespace {
+
+class TestNodePath : public gobot::NodePath {
+public:
+    TestNodePath() = default;
+};
+
+}
+
+TEST(TestNodePath, test_ctor) {
+    gobot::String path = "/root";
+    gobot::NodePath node_path(path);
+
+
+}

--- a/tests/scene/test_node_path.cpp
+++ b/tests/scene/test_node_path.cpp
@@ -20,24 +20,8 @@ public:
 
 }
 
-//TEST(TestNodePath, test_ctor) {
-//    gobot::String path = "/root";
-//    gobot::NodePath node_path(path);
-
 TEST(TestNodePath, rel_path) {
     const gobot::NodePath node_path_relative = gobot::NodePath("/Path2D/PathFollow2D/Sprite2D:position:x");
 
     ASSERT_TRUE(node_path_relative.IsAbsolute() == true);
-
-    std::cout << "GetNames: ";
-    for (const auto& str : node_path_relative.GetNames()) {
-        std::cout << str.toStdString() << " ";
-    }
-    std::cout << std::endl;
-
-    std::cout << "GetSubNames: ";
-    for (const auto& str : node_path_relative.GetSubNames()) {
-        std::cout << str.toStdString() << " ";
-    }
-    std::cout << std::endl;
 }

--- a/tests/scene/test_node_path.cpp
+++ b/tests/scene/test_node_path.cpp
@@ -6,9 +6,9 @@
 */
 
 #include <gtest/gtest.h>
+#include <iostream>
 
-//#include <gobot/log.hpp>
-#include <gobot/core/types.hpp>
+#include <gobot/log.hpp>
 #include <gobot/scene/node_path.hpp>
 
 namespace {
@@ -20,9 +20,24 @@ public:
 
 }
 
-TEST(TestNodePath, test_ctor) {
-    gobot::String path = "/root";
-    gobot::NodePath node_path(path);
+//TEST(TestNodePath, test_ctor) {
+//    gobot::String path = "/root";
+//    gobot::NodePath node_path(path);
 
+TEST(TestNodePath, rel_path) {
+    const gobot::NodePath node_path_relative = gobot::NodePath("/Path2D/PathFollow2D/Sprite2D:position:x");
 
+    ASSERT_TRUE(node_path_relative.IsAbsolute() == true);
+
+    std::cout << "GetNames: ";
+    for (const auto& str : node_path_relative.GetNames()) {
+        std::cout << str.toStdString() << " ";
+    }
+    std::cout << std::endl;
+
+    std::cout << "GetSubNames: ";
+    for (const auto& str : node_path_relative.GetSubNames()) {
+        std::cout << str.toStdString() << " ";
+    }
+    std::cout << std::endl;
 }

--- a/tests/scene/test_node_path.cpp
+++ b/tests/scene/test_node_path.cpp
@@ -10,14 +10,6 @@
 #include <gobot/log.hpp>
 #include <gobot/scene/node_path.hpp>
 
-namespace {
-
-class TestNodePath : public gobot::NodePath {
-public:
-    TestNodePath() = default;
-};
-
-}
 
 TEST(TestNodePath, relative_path) {
     const gobot::NodePath node_path_relative = gobot::NodePath("Path2D/PathFollow2D/Sprite2D:position:x");

--- a/tests/scene/test_node_path.cpp
+++ b/tests/scene/test_node_path.cpp
@@ -6,7 +6,6 @@
 */
 
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include <gobot/log.hpp>
 #include <gobot/scene/node_path.hpp>


### PR DESCRIPTION
A pre-parsed relative or absolute path in a scene tree, for use with Node related functionalities. It can reference a node, a resource within a node, or a property of a node or resource.

Following methods are implemented.
- IsAbsolute
- GetNameCount
- GetName
- GetSubNameCount
- GetSubName
- GetNames
- GetSubNames
- GetConcatenatedNames
- GetConcatenatedSubNames
- GetAsPropertyPath
- operator String()
- IsEmpty
- operator==
- operator!=
- Simplify
- Simplified

Added ERR_FAIL_INDEX_V and ERR_FAIL_INDEX_MSG for error logs.