### PR TITLE
Test type of  NodePath 

### DIFF
--- a/include/gobot/scene/node_path.hpp
+++ b/include/gobot/scene/node_path.hpp
@@ -8,9 +8,10 @@
 
 #pragma once
 
-#include "gobot/log.hpp"
 #include "gobot/error_marcos.hpp"
 #include "gobot/core/types.hpp"
+#include "gobot/core/marcos.hpp"
+#include "gobot/log.hpp"
 #include <vector>
 #include <QStringList>
 
@@ -51,7 +52,7 @@ public:
      *
      * @returns number of node names.
      */
-    [[nodiscard]] ulong GetNameCount() const;
+    [[nodiscard]] std::size_t GetNameCount() const;
 
     /**
      * @brief Gets the node name indicated by idx (0 to GetNameCount - 1).
@@ -68,7 +69,7 @@ public:
      *
      * @returns number of node subnames.
      */
-    [[nodiscard]] ulong GetSubNameCount() const;
+    [[nodiscard]] std::size_t GetSubNameCount() const;
 
     /**
      * @brief Gets the resource or property name indicated by idx (0 to GetSubnameCount).
@@ -143,6 +144,11 @@ public:
     [[nodiscard]] NodePath Simplified() const;
 
 private:
+    // For rttr
+    void SetStrData(const String& str);
+
+    String GeStrData();
+
     struct Data {
         std::vector<String> path = std::vector<String>();
         std::vector<String> subpath = std::vector<String>();
@@ -155,7 +161,18 @@ private:
 
     mutable Data data_;
 
-    static constexpr Qt::SplitBehaviorFlags S_FLAG_SKIP_EMPTY_PARTS = Qt::SkipEmptyParts;
+    static constexpr Qt::SplitBehaviorFlags s_split_behavior_flags = Qt::SkipEmptyParts;
+
+    GOBOT_REGISTRATION_FRIEND
 };
 
 }
+
+template<>
+struct fmt::formatter<gobot::NodePath> : fmt::formatter<std::string>
+{
+    static auto format(const gobot::NodePath& node_path, format_context &ctx) -> decltype(ctx.out())
+    {
+        return fmt::formatter<gobot::String>::format(node_path.operator gobot::String(), ctx);
+    }
+};

--- a/src/gobot/core/io/object_serialize.cpp
+++ b/src/gobot/core/io/object_serialize.cpp
@@ -235,7 +235,7 @@
 //
 //    to_json_recursively(obj, writer);
 //
-//    return sb.GetString();
+//    return sb.GeStrData();
 //}
 //
 //core::Json ObjectToJson(rttr::instance obj);

--- a/src/gobot/scene/node.cpp
+++ b/src/gobot/scene/node.cpp
@@ -13,4 +13,8 @@ Node::Node() {
 
 }
 
+void Node::Notification(NotificationType notification) {
+
+}
+
 }

--- a/src/gobot/scene/node_path.cpp
+++ b/src/gobot/scene/node_path.cpp
@@ -36,7 +36,7 @@ NodePath::NodePath(const String &path) {
     int subpath_pos = path.indexOf(u':');
 
     if (subpath_pos >= 0) {
-        subpath_list = raw_path.split(u':', S_FLAG_SKIP_EMPTY_PARTS).toVector();
+        subpath_list = raw_path.split(u':', s_split_behavior_flags).toVector();
         if (subpath_pos > 0) {
             raw_path = subpath_list.front();
             subpath_list.pop_front();
@@ -51,7 +51,7 @@ NodePath::NodePath(const String &path) {
         path_list = Vector<String>();
     } else {
         if (is_absolute) raw_path.remove(0, 1);
-        path_list = raw_path.split(u'/', S_FLAG_SKIP_EMPTY_PARTS).toVector();
+        path_list = raw_path.split(u'/', s_split_behavior_flags).toVector();
         if (path_list.isEmpty())
             path_list = Vector<String>(raw_path.size(), raw_path);
     }
@@ -192,15 +192,20 @@ NodePath NodePath::Simplified() const {
     return np;
 }
 
+void NodePath::SetStrData(const String& str) {
+    *this = NodePath(str);
+}
+
+String NodePath::GeStrData() {
+    return this->operator String();
+}
+
+
 } // End of namespace gobot
 
 GOBOT_REGISTRATION {
 
     Class_<NodePath>("NodePath")
-            .constructor<const std::vector<String>&, bool>()(CtorAsObject)
-            .constructor<const std::vector<String>&, const std::vector<String>, bool>()(CtorAsObject)
-            .constructor<const NodePath&>()(CtorAsObject)
-            .constructor<const String&>()(CtorAsObject)
             .constructor()(CtorAsObject)
 
             .property_readonly("is_absolute", &NodePath::IsAbsolute)
@@ -213,6 +218,9 @@ GOBOT_REGISTRATION {
             .property_readonly("subname_path", &NodePath::GetConcatenatedSubNames)
             .property_readonly("to_property_path", &NodePath::GetAsPropertyPath)
             .property_readonly("simplified", &NodePath::Simplified)
+            .property_readonly("to_string", &NodePath::operator String)
+
+            .property("str_data", &NodePath::GeStrData, &NodePath::SetStrData)
 
             .method("get_name", &NodePath::GetName)
             .method("get_subname", &NodePath::GetSubName)

--- a/tests/scene/test_node_path.cpp
+++ b/tests/scene/test_node_path.cpp
@@ -133,3 +133,16 @@ TEST(TestNodePath, complex_path) {
     // The returned concatenated subnames should match the expected value.
     ASSERT_TRUE(node_path_simplified.GetConcatenatedSubNames() == "position:x");
 }
+
+TEST(TestNodePath, test_type) {
+    gobot::Variant var = gobot::NodePath("/home/gobot");
+    auto node_path = var.convert<gobot::NodePath>();
+
+    auto prop = var.get_type().get_property("str_data");
+    ASSERT_TRUE(prop.get_value(var).to_string() == "/home/gobot");
+
+    auto type = gobot::Type::get_by_name("NodePath");
+    auto var2 = type.create();
+    prop.set_value(var2, gobot::String("/home/gobot"));
+    ASSERT_TRUE(prop.get_value(var2).to_string() == "/home/gobot");
+}

--- a/tests/scene/test_node_path.cpp
+++ b/tests/scene/test_node_path.cpp
@@ -137,6 +137,8 @@ TEST(TestNodePath, complex_path) {
 TEST(TestNodePath, test_type) {
     gobot::Variant var = gobot::NodePath("/home/gobot");
     auto node_path = var.convert<gobot::NodePath>();
+    ASSERT_TRUE(node_path.operator gobot::
+    String() == gobot::String("/home/gobot"));
 
     auto prop = var.get_type().get_property("str_data");
     ASSERT_TRUE(prop.get_value(var).to_string() == "/home/gobot");

--- a/tests/scene/test_node_path.cpp
+++ b/tests/scene/test_node_path.cpp
@@ -147,4 +147,7 @@ TEST(TestNodePath, test_type) {
     auto var2 = type.create();
     prop.set_value(var2, gobot::String("/home/gobot"));
     ASSERT_TRUE(prop.get_value(var2).to_string() == "/home/gobot");
+
+    auto node_path2 = var2.convert<gobot::NodePath>();
+    ASSERT_TRUE(node_path2.operator gobot::String() == gobot::String("/home/gobot"));
 }


### PR DESCRIPTION
`
auto type = gobot::Type::get_by_name("NodePath");
auto var2 = type.create();
`

The piece of code show creating a NodePath type and using this type to create a new instance(call constructor of NodePath, and using policy CtorAsObject).

Even though, rttr support call contructor with parameter, but we always using non-parameter constructor because we don't want to memorize parameter counts and type of contructor.